### PR TITLE
fix TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 - [Standalones](#standalones)
 - [Sourceports](#sourceports)
-- [Mapping](#mapping)
 - [Playing](#playing)
+- [Mapping](#mapping)
 - [Modeling](#modeling)
 - [Modding](#modding)
 - [Mods](#mods)


### PR DESCRIPTION
Section order in table of contents should match the order in document body.
